### PR TITLE
footer not showing if earlier call to showConsentTool was made

### DIFF
--- a/src/complete.js
+++ b/src/complete.js
@@ -9,7 +9,7 @@ import { init } from './lib/init';
 import { CMP_GLOBAL_NAME } from "./lib/cmp";
 import configuration from "./lib/config";
 
-function handleConsentResult(cmp, {vendorListVersion: listVersion} = {}, {created, vendorListVersion} = {}) {
+function handleConsentResult(cmp, {isConsentToolShowing}, {vendorListVersion: listVersion} = {}, {created, vendorListVersion} = {}) {
 	if (!created) {
 		log.debug('No consent data found. Showing consent tool');
 		configuration.autoDisplay && cmp('showConsentTool');
@@ -23,11 +23,11 @@ function handleConsentResult(cmp, {vendorListVersion: listVersion} = {}, {create
 	}
 	else {
 		log.debug('Consent found. Not showing consent tool. Show footer when not all consents set to true');
-		configuration.autoDisplay && cmp('showFooter');
+		!isConsentToolShowing && configuration.autoDisplay && cmp('showFooter');
 	}
 }
 
-function checkConsent(cmp) {
+function checkConsent(cmp, store) {
 	if (!cmp) {
 		log.error('CMP failed to load');
 	}
@@ -37,12 +37,12 @@ function checkConsent(cmp) {
 	else {
 		cmp('getVendorList', null, vendorList => {
 			const timeout = setTimeout(() => {
-				handleConsentResult(cmp, vendorList);
+				handleConsentResult(cmp, store, vendorList);
 			}, 100);
 
 			cmp('getVendorConsents', null, vendorConsents => {
 				clearTimeout(timeout);
-				handleConsentResult(cmp, vendorList, vendorConsents);
+				handleConsentResult(cmp, store, vendorList, vendorConsents);
 			});
 		});
 	}
@@ -104,4 +104,4 @@ listen('message', event => {
 }, false);
 
 // Initialize CMP and then check if we need to ask for consent
-init(configUpdates).then(() => checkConsent(window.__cmp));
+init(configUpdates).then((store) => checkConsent(window.__cmp, store));

--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -103,7 +103,7 @@ export function init(configUpdates) {
 			return Promise.all([
 				store,
 				fetchGlobalVendorList().then(store.updateVendorList),
-				fetchPurposeList().then(store.updateCustomPurposeList),
+				fetchPurposeList().then(store.updateCustomPurposeList)
 			]).then((params) => {
 				cmp.cmpReady = true;
 				cmp.notify('cmpReady');

--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -101,13 +101,13 @@ export function init(configUpdates) {
 
 			// Request lists
 			return Promise.all([
+				store,
 				fetchGlobalVendorList().then(store.updateVendorList),
 				fetchPurposeList().then(store.updateCustomPurposeList),
-				store
-			]).then((store) => {
+			]).then((params) => {
 				cmp.cmpReady = true;
 				cmp.notify('cmpReady');
-				return store[2];
+				return params[0];
 			}).catch(err => {
 				log.error('Failed to load lists. CMP not ready', err);
 			});

--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -102,10 +102,12 @@ export function init(configUpdates) {
 			// Request lists
 			return Promise.all([
 				fetchGlobalVendorList().then(store.updateVendorList),
-				fetchPurposeList().then(store.updateCustomPurposeList)
-			]).then(() => {
+				fetchPurposeList().then(store.updateCustomPurposeList),
+				store
+			]).then((store) => {
 				cmp.cmpReady = true;
 				cmp.notify('cmpReady');
+				return store[2];
 			}).catch(err => {
 				log.error('Failed to load lists. CMP not ready', err);
 			});


### PR DESCRIPTION
Bug was found, when there is delay in vendor list request, and call to dlApi.cmp('showConsentTool') is made. In this scenario Consent tool was shown for a short amount of time and then it was replaced by footer. Problem may affect mobile applications.  The solution is to pass store to handleConsentResult function and show footer only if consent tool is not showing.