### PR TITLE
Add button which handle accept/reject all vendors

### DIFF
--- a/src/components/popup/details/vendors/vendors.jsx
+++ b/src/components/popup/details/vendors/vendors.jsx
@@ -42,7 +42,16 @@ export default class Vendors extends Component {
 		});
 	};
 
-	getActiveAttributesNameElements = (setOfAttributes, idsOfActiveAttributes, translationPrefix='') => {
+	isFullVendorsConsentChosen = () => {
+		const {vendors, selectedVendorIds} = this.props;
+		return vendors.length === selectedVendorIds.size;
+	};
+
+	handleFullConsentChange = ({isSelected}) => {
+		isSelected ? this.handleAcceptAll() : this.handleRejectAll();
+	};
+
+	getActiveAttributesNameElements = (setOfAttributes, idsOfActiveAttributes, translationPrefix = '') => {
 		const activeAttributes = setOfAttributes
 			.filter(attribute => idsOfActiveAttributes.indexOf(attribute['id']) !== -1)
 			.map(attribute => <Label localizeKey={`${translationPrefix}${attribute['id']}.title`}>{attribute['name']}</Label>);
@@ -85,7 +94,15 @@ export default class Vendors extends Component {
 						<tr>
 							<th><LocalLabel localizeKey='company'>Company</LocalLabel></th>
 							{editingConsents &&
+							<span>
 							<th><LocalLabel localizeKey='offOn'>Allow</LocalLabel></th>
+							<th>
+								<Switch
+									isSelected={this.isFullVendorsConsentChosen()}
+									onClick={this.handleFullConsentChange}
+								/>
+							</th>
+							</span>
 							}
 						</tr>
 						</thead>

--- a/src/components/popup/details/vendors/vendors.test.js
+++ b/src/components/popup/details/vendors/vendors.test.js
@@ -93,6 +93,34 @@ describe('Vendors', () => {
 		expect(selectAllVendors.mock.calls[0][0]).to.equal(true);
 	});
 
+	it('should handle accepting all vendors if some vendors are rejected', () => {
+		const selectAllVendors = jest.fn();
+
+		let vendors;
+		render(<Vendors
+			ref={ref => vendors = ref}
+			vendors={[
+				{id: 1, name: 'Vendor 1', purposeIds: [1], legIntPurposeIds: [2], featureIds: []},
+				{id: 2, name: 'Vendor 2', purposeIds: [], legIntPurposeIds: [1], featureIds: []},
+				{id: 3, name: 'Vendor 3', purposeIds: [1], legIntPurposeIds: [2], featureIds: [1]},
+				{id: 4, name: 'Vendor 4', purposeIds: [2], legIntPurposeIds: [1], featureIds: [1, 2]}
+			]}
+			purposes={[
+				{id: 1, name: 'Purpose 1'},
+				{id: 2, name: 'Purpose 2'},
+			]}
+			features={[
+				{id: 1, name: 'Feature 1'},
+				{id: 2, name: 'Feature 2'},
+			]}
+			selectAllVendors={selectAllVendors}
+		/>, scratch);
+
+
+		vendors.handleFullConsentChange({isSelected: true});
+		expect(selectAllVendors.mock.calls[0][0]).to.equal(true);
+	});
+
 	it('should handle rejecting all vendors', () => {
 		const selectAllVendors = jest.fn();
 
@@ -118,5 +146,83 @@ describe('Vendors', () => {
 
 		vendors.handleRejectAll();
 		expect(selectAllVendors.mock.calls[0][0]).to.equal(false);
+	});
+
+	it('should handle rejecting all vendors if some vendors are selected', () => {
+		const selectAllVendors = jest.fn();
+
+		let vendors;
+		render(<Vendors
+			ref={ref => vendors = ref}
+			vendors={[
+				{id: 1, name: 'Vendor 1', purposeIds: [1], legIntPurposeIds: [2], featureIds: []},
+				{id: 2, name: 'Vendor 2', purposeIds: [], legIntPurposeIds: [1], featureIds: []},
+				{id: 3, name: 'Vendor 3', purposeIds: [1], legIntPurposeIds: [2], featureIds: [1]},
+				{id: 4, name: 'Vendor 4', purposeIds: [2], legIntPurposeIds: [1], featureIds: [1, 2]}
+			]}
+			purposes={[
+				{id: 1, name: 'Purpose 1'},
+				{id: 2, name: 'Purpose 2'},
+			]}
+			features={[
+				{id: 1, name: 'Feature 1'},
+				{id: 2, name: 'Feature 2'},
+			]}
+			selectAllVendors={selectAllVendors}
+		/>, scratch);
+
+
+		vendors.handleFullConsentChange({isSelected: false});
+		expect(selectAllVendors.mock.calls[0][0]).to.equal(false);
+	});
+
+	it('should return true if all vendors are accepted', () => {
+		let vendors;
+		render(<Vendors
+			ref={ref => vendors = ref}
+			vendors={[
+				{id: 1, name: 'Vendor 1', purposeIds: [1], legIntPurposeIds: [2], featureIds: []},
+				{id: 2, name: 'Vendor 2', purposeIds: [], legIntPurposeIds: [1], featureIds: []},
+				{id: 3, name: 'Vendor 3', purposeIds: [1], legIntPurposeIds: [2], featureIds: [1]},
+				{id: 4, name: 'Vendor 4', purposeIds: [2], legIntPurposeIds: [1], featureIds: [1, 2]}
+			]}
+			purposes={[
+				{id: 1, name: 'Purpose 1'},
+				{id: 2, name: 'Purpose 2'},
+			]}
+			features={[
+				{id: 1, name: 'Feature 1'},
+				{id: 2, name: 'Feature 2'},
+			]}
+			selectedVendorIds={new Set([1, 2, 3, 4])}
+		/>, scratch);
+
+		const result = vendors.isFullVendorsConsentChosen();
+		expect(result).to.equal(true);
+	});
+
+	it('should return false if some vendors are rejected', () => {
+		let vendors;
+		render(<Vendors
+			ref={ref => vendors = ref}
+			vendors={[
+				{id: 1, name: 'Vendor 1', purposeIds: [1], legIntPurposeIds: [2], featureIds: []},
+				{id: 2, name: 'Vendor 2', purposeIds: [], legIntPurposeIds: [1], featureIds: []},
+				{id: 3, name: 'Vendor 3', purposeIds: [1], legIntPurposeIds: [2], featureIds: [1]},
+				{id: 4, name: 'Vendor 4', purposeIds: [2], legIntPurposeIds: [1], featureIds: [1, 2]}
+			]}
+			purposes={[
+				{id: 1, name: 'Purpose 1'},
+				{id: 2, name: 'Purpose 2'},
+			]}
+			features={[
+				{id: 1, name: 'Feature 1'},
+				{id: 2, name: 'Feature 2'},
+			]}
+			selectedVendorIds={new Set([1])}
+		/>, scratch);
+
+		const result = vendors.isFullVendorsConsentChosen();
+		expect(result).to.equal(false);
 	});
 });


### PR DESCRIPTION
Add button provides possiblity to accept or reject all vendors with one click. 

Usage cases:
When all vendors are selected, button state is ON. Click deactivate all vendors. 
When all vendors are rejected, button state is OFF. Click active all vendors.
When some of vendors are rejected, button state is OFF. Click active all vendors.
