### PR TITLE
Bugfix/center cmp footer msg

### DIFF
--- a/src/components/closebutton/closebutton.less
+++ b/src/components/closebutton/closebutton.less
@@ -29,7 +29,6 @@
 }
 
 .closeButtonWrapper {
-	width: 100%;
 	display: flex;
 	justify-content: flex-end;
 	cursor: pointer;


### PR DESCRIPTION
A text in the footer that is displayed on the screen after user changes default gdpr preferences is aligned right.
This fix restores the central aligment of the text there.